### PR TITLE
Implement CorDA

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -54,6 +54,30 @@ lora_config = LoraConfig(init_lora_weights="pissa_niter_[number of iters]", ...)
 ```
 For detailed instruction on using PiSSA, please follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/pissa_finetuning).
 
+### CorDA
+
+[CorDA](https://arxiv.org/pdf/2406.05223) builds task-aware LoRA adapters from weight decomposition oriented by the context of downstream task to learn (IPM) or world knowledge to maintain (KPM).
+The KPM not only achieves better performance than LoRA on fine-tuning tasks, but also mitigates the catastrophic forgetting of pre-trained world knowledge.
+When preserving pre-trained knowledge is not a concern, 
+the IPM is favored because it can further accelerate convergence and enhance the fine-tuning performance. 
+
+You need to configure the initialization method to "corda", and specify the mode of IPM or KPM and the dataset to collect covariance matrices. 
+
+```py
+from peft import LoraConfig
+
+corda_config = CordaConfig(
+    run_model=run_model,  # The function to run the model on the dataset
+    sample_count=256,
+    corda_method="ipm",
+)
+lora_config = LoraConfig(
+    init_lora_weights="corda",
+)
+```
+
+For detailed instruction on using CorDA, please follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/corda_finetuning).
+
 ### OLoRA
 [OLoRA](https://arxiv.org/abs/2406.01775) utilizes QR decomposition to initialize the LoRA adapters. OLoRA translates the base weights of the model by a factor of their QR decompositions, i.e., it mutates the weights before performing any training on them. This approach significantly improves stability, accelerates convergence speed, and ultimately achieves superior performance.
 

--- a/examples/corda_finetuning/README.md
+++ b/examples/corda_finetuning/README.md
@@ -1,0 +1,128 @@
+# CorDA: Context-Oriented Decomposition Adaptation of Large Language Models for Task-Aware Parameter-Efficient Fine-tuning
+
+## Introduction
+
+
+Existing PEFT methods are mostly agnoistic of the context of a task of concern, e.g., a downstream task to learn or some pre-trained world knowledge to maintain.
+[CorDA](https://openreview.net/pdf?id=Gi00NVru6n) builds task-aware LoRA adapters from weight decomposition oriented by the context of the task concerned. 
+
+Concretely, CorDA randomly collect a few (usually 256) data samples from a target task, e.g. questions from a QA dataset or instructions to write a code or solve a math problem, and feed these samples into a pre-trained LLM. We can obtain the covariance matrix of the input activation of each linear layer, i.e., $C=XX^T\in\mathcal{R}^{d_{in}\times d_{in}}$, where $X$ is the input of this linear layer. 
+We then perform singular value decomposition (SVD) for the weight $W\in \mathcal{R}^{d_{out}\times d_{in}}$ multiplied by the covariance matrix, i.e., $\verb|SVD|(WC) = U\Sigma V^T$, where $U$ and $V$ are singular vectors and $\Sigma$ is the diagonal matrix with the singular values arranged in descending order. In this way, the context expressed by these representative covariance matrices is able to orientate the decomposition, such that the principal components are most associated with the task of concern. To ensure the same inference result with the pre-trained model at the start of adaptation, we multiply the inverse of these covariance matrices with the decomposed components, $\hat{W}=U\Sigma V^T C^{-1}$, where $\hat{W}$ is the weight after decomposition and reconstruction. 
+
+Thanks to the task-awareness, CorDA enables two optional modes, **knowledge-preserving adaptation mode (KPM)** and **instruction-previewed adaptation mode (IPM**). In KPM, we use questions from question-answering dataset whose knowledge needs to be preserved, such as TriviaQA and NQopen, to obtain the covariance matrices. After our context-oriented decomposition, we use the components with the smallest $r$ singular values, $U_{[:,-r:]}$, $\Sigma_{[-r:]}$, and $(V^T C^{-1})_{[-r:,:]}$ to initialize the learnable LoRA adapters $A=\sqrt{\Sigma}_{[-r:]}(V^T C^{-1})_{[-r:,:]}$ and $B=U_{[:,-r:]}\sqrt{\Sigma}_{[-r:]}$. The other components that compact the question-answering ability are frozen during adaptation. 
+KPM enables to learn new tasks effectively while keeping the world knowledge associated with $C$ as sound
+as possible.
+Alternatively, when one only aims to achieve performance as high as possible on the finetuning task without concern for world knowledge maintenance, our IPM will be favored. 
+In this mode, CorDA uses the instruction and response from the fine-tuning task (e.g., Math or Code) to produce the covariance matrices. The principal components with large singular values capturing the characteristics of the finetuning task in advance can better accommodate the new ability. So we initialize adapters as $A= \sqrt{\Sigma}_{[:r]} (V^T C^{-1})_{[:r,:]}$ and $B =U_{[:,:r]} \sqrt{\Sigma}_{[:r]}$, and freeze the remaining components. The implementations of KPM and IPM are compared as follows:
+
+| Mode | Collect covariance from | LoRA $A$ | LoRA $B$ |
+|---|---|---|---
+|KPM | questions from a knowledge benchmark to maintain | $A=\sqrt{\Sigma}_{[-r:]}(V^T C^{-1})_{[-r:,:]}$ | $B=U_{[:,-r:]}\sqrt{\Sigma}_{[-r:]}$ |
+IPM | instructions and responses from a downstream task to learn | $A= \sqrt{\Sigma}_{[:r]} (V^T C^{-1})_{[:r,:]}$ | $B =U_{[:,:r]} \sqrt{\Sigma}_{[:r]}$ |
+
+
+
+## Quick Start
+
+- Knowledge-preserving adaptation mode
+
+```py
+import torch
+from peft import LoraConfig, get_peft_model
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from peft.tuners.lora.config import CordaConfig
+from trl import SFTConfig, SFTTrainer
+from datasets import load_dataset
+
+model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b-hf", torch_dtype=torch.bfloat16, device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+tokenizer.pad_token_id = tokenizer.eos_token_id
+sampled_dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train[:256]")
+dataset = load_dataset("imdb", split="train[:256]")
+
+
+def run_model():
+    for batch in sampled_dataset:
+        input_ids = batch["text"]
+        input_ids = input_ids.to(model.device)
+        with torch.no_grad():
+            model(input_ids)
+
+
+corda_config = CordaConfig(
+    run_model=run_model,
+    sample_count=256,
+    corda_method="kpm",
+)
+lora_config = LoraConfig(
+    init_lora_weights="corda",
+)
+peft_model = get_peft_model(model, lora_config)
+peft_model.print_trainable_parameters()
+
+training_args = SFTConfig(dataset_text_field="text", max_seq_length=128)
+trainer = SFTTrainer(
+    model=peft_model,
+    args=training_args,
+    train_dataset=dataset,
+    tokenizer=tokenizer,
+)
+trainer.train()
+peft_model.save_pretrained("corda-llama-2-7b")
+```
+
+- Instruction-previewed adaptation mode
+
+```py
+import torch
+from peft import LoraConfig, get_peft_model
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from peft.tuners.lora.config import CordaConfig
+from trl import SFTConfig, SFTTrainer
+from datasets import load_dataset
+
+model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b-hf", torch_dtype=torch.bfloat16, device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+tokenizer.pad_token_id = tokenizer.eos_token_id
+dataset = load_dataset("imdb", split="train[:256]")
+
+
+def run_model():
+    for batch in dataset:
+        input_ids = batch["text"]
+        input_ids = input_ids.to(model.device)
+        with torch.no_grad():
+            model(input_ids)
+
+
+corda_config = CordaConfig(
+    run_model=run_model,
+    sample_count=256,
+    corda_method="ipm",
+)
+lora_config = LoraConfig(
+    init_lora_weights="corda",
+)
+peft_model = get_peft_model(model, lora_config)
+peft_model.print_trainable_parameters()
+
+training_args = SFTConfig(dataset_text_field="text", max_seq_length=128)
+trainer = SFTTrainer(
+    model=peft_model,
+    args=training_args,
+    train_dataset=dataset,
+    tokenizer=tokenizer,
+)
+trainer.train()
+peft_model.save_pretrained("corda-llama-2-7b")
+```
+
+## Citation
+```
+@inproceedings{yangcorda,
+  title={CorDA: Context-Oriented Decomposition Adaptation of Large Language Models for Task-Aware Parameter-Efficient Fine-tuning},
+  author={Yang, Yibo and Li, Xiaojie and Zhou, Zhongzhu and Song, Shuaiwen Leon and Wu, Jianlong and Nie, Liqiang and Ghanem, Bernard},
+  booktitle={The Thirty-eighth Annual Conference on Neural Information Processing Systems},
+  year={2024},
+}
+```

--- a/examples/corda_finetuning/corda_finetuning.py
+++ b/examples/corda_finetuning/corda_finetuning.py
@@ -1,0 +1,267 @@
+import copy
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+import torch
+import transformers
+from datasets import load_dataset
+from transformers import Trainer
+
+from peft import LoraConfig, PeftModel, get_peft_model
+
+
+IGNORE_INDEX = -100
+
+PROMPT = (
+    "Below is an instruction that describes a task. "
+    "Write a response that appropriately completes the request.\n\n"
+    "### Instruction:\n{instruction}\n\n### Response:"
+)
+
+
+def get_nb_trainable_parameters(model) -> tuple[int, int]:
+    r"""
+    Returns the number of trainable parameters and the number of all parameters in the model.
+    """
+    trainable_params = 0
+    all_param = 0
+    for _, param in model.named_parameters():
+        num_params = param.numel()
+        # if using DS Zero 3 and the weights are initialized empty
+        if num_params == 0 and hasattr(param, "ds_numel"):
+            num_params = param.ds_numel
+
+        # Due to the design of 4bit linear layers from bitsandbytes
+        # one needs to multiply the number of parameters by 2 to get
+        # the correct number of parameters
+        if param.__class__.__name__ == "Params4bit":
+            num_bytes = param.quant_storage.itemsize if hasattr(param, "quant_storage") else 1
+            num_params = num_params * 2 * num_bytes
+
+        all_param += num_params
+        if param.requires_grad:
+            trainable_params += num_params
+
+    return trainable_params, all_param
+
+
+@dataclass
+class TrainingArguments(transformers.TrainingArguments):
+    model_name_or_path: Optional[str] = field(default="facebook/opt-125m")
+    # adapter_name_or_path: Optional[str] = field(default=None)
+    data_path: str = field(default=None, metadata={"help": "Path to the training data."})
+    dataset_split: str = field(default="train[:100000]", metadata={"help": "(`['train', 'test', 'eval']`):"})
+    dataset_field: List[str] = field(default=None, metadata={"help": "Fields of dataset input and output."})
+    optim: str = field(default="adamw_torch")
+    model_max_length: int = field(
+        default=512,
+        metadata={"help": "Maximum sequence length. Sequences will be right padded (and possibly truncated)."},
+    )
+    lora_r: int = field(
+        default=None,
+        metadata={"help": "The rank of LoRA adapter. When passing `None`, CorDA or full fine-tuning is used."},
+    )
+    # init_lora_weights: Literal[True, "pissa"] = field(
+    #    default=True,
+    # )
+    corda_mode: bool = field(default=True, metadata={"help": "True for CorDA mode"})
+
+
+def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: str):
+    """Collects the state dict and dump to disk."""
+    state_dict = trainer.model.state_dict()
+    if trainer.args.should_save:
+        cpu_state_dict = {key: value.cpu() for key, value in state_dict.items()}
+        del state_dict
+        trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
+
+
+def smart_tokenizer_and_embedding_resize(
+    special_tokens_dict: Dict,
+    tokenizer: transformers.PreTrainedTokenizer,
+    model: transformers.PreTrainedModel,
+):
+    """Resize tokenizer and embedding.
+
+    Note: This is the unoptimized version that may make your embedding size not be divisible by 64.
+    """
+    num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict)
+    model.resize_token_embeddings(len(tokenizer))
+
+    if num_new_tokens > 0:
+        input_embeddings = model.get_input_embeddings().weight.data
+        output_embeddings = model.get_output_embeddings().weight.data
+
+        input_embeddings_avg = input_embeddings[:-num_new_tokens].mean(dim=0, keepdim=True)
+        output_embeddings_avg = output_embeddings[:-num_new_tokens].mean(dim=0, keepdim=True)
+
+        input_embeddings[-num_new_tokens:] = input_embeddings_avg
+        output_embeddings[-num_new_tokens:] = output_embeddings_avg
+
+
+def _tokenize_fn(strings: Sequence[str], tokenizer: transformers.PreTrainedTokenizer) -> Dict:
+    """Tokenize a list of strings."""
+    tokenized_list = [
+        tokenizer(
+            text,
+            return_tensors="pt",
+            padding="longest",
+            max_length=tokenizer.model_max_length,
+            truncation=True,
+        )
+        for text in strings
+    ]
+    input_ids = labels = [tokenized.input_ids[0] for tokenized in tokenized_list]
+    input_ids_lens = labels_lens = [
+        tokenized.input_ids.ne(tokenizer.pad_token_id).sum().item() for tokenized in tokenized_list
+    ]
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+        "input_ids_lens": input_ids_lens,
+        "labels_lens": labels_lens,
+    }
+
+
+def preprocess(
+    sources: Sequence[str],
+    targets: Sequence[str],
+    tokenizer: transformers.PreTrainedTokenizer,
+) -> Dict:
+    """Preprocess the data by tokenizing."""
+    examples = [s + t for s, t in zip(sources, targets)]
+    examples_tokenized, sources_tokenized = (_tokenize_fn(strings, tokenizer) for strings in (examples, sources))
+    input_ids = examples_tokenized["input_ids"]
+    labels = copy.deepcopy(input_ids)
+    for label, source_len in zip(labels, sources_tokenized["input_ids_lens"]):
+        label[:source_len] = IGNORE_INDEX
+    return {
+        "input_ids": input_ids,
+        "labels": labels,
+    }
+
+
+@dataclass
+class DataCollatorForSupervisedDataset:
+    """Collate examples for supervised fine-tuning."""
+
+    tokenizer: transformers.PreTrainedTokenizer
+
+    def __call__(self, instances: Sequence[Dict]) -> Dict[str, torch.Tensor]:
+        input_ids, labels = tuple([instance[key] for instance in instances] for key in ("input_ids", "labels"))
+        input_ids = [torch.tensor(x) for x in input_ids]
+        input_ids = torch.nn.utils.rnn.pad_sequence(
+            input_ids, batch_first=True, padding_value=self.tokenizer.pad_token_id
+        )
+        labels = [torch.tensor(x) for x in labels]
+        labels = torch.nn.utils.rnn.pad_sequence(labels, batch_first=True, padding_value=IGNORE_INDEX)
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "attention_mask": input_ids.ne(self.tokenizer.pad_token_id),
+        }
+
+
+def train_tokenize_function(examples, tokenizer, query, response):
+    sources = [
+        PROMPT.format_map(
+            {
+                "instruction": instruction,
+            }
+        )
+        for instruction in examples[query]
+    ]
+    targets = [f"{output}{tokenizer.eos_token}" for output in examples[response]]
+    data_dict = preprocess(sources, targets, tokenizer)
+    return data_dict
+
+
+def train():
+    parser = transformers.HfArgumentParser(TrainingArguments)
+    script_args = parser.parse_args_into_dataclasses()[0]
+    print(script_args)
+
+    if script_args.corda_mode:
+        print("Train in CorDA mode")
+        res_model = transformers.AutoModelForCausalLM.from_pretrained(
+            script_args.model_name_or_path,
+            device_map="auto",
+        )
+        model = PeftModel.from_pretrained(
+            res_model, script_args.model_name_or_path, subfolder="corda_init", is_trainable=True
+        )
+    elif script_args.lora_r is not None:
+        print("Train in LoRA mode")
+        model = transformers.AutoModelForCausalLM.from_pretrained(
+            script_args.model_name_or_path,
+            device_map="auto",
+        )
+        lora_config = LoraConfig(
+            r=script_args.lora_r,
+            lora_alpha=script_args.lora_r,
+            init_lora_weights=True,  # script_args.init_lora_weights,
+            target_modules=["q_proj", "o_proj", "k_proj", "v_proj", "gate_proj", "up_proj", "down_proj"],
+            lora_dropout=0,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+        model = get_peft_model(model, lora_config)
+    else:
+        print("Train in Full Finetuning mode")
+        model = transformers.AutoModelForCausalLM.from_pretrained(
+            script_args.model_name_or_path,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+        )
+    print(model)
+
+    for n, p in model.named_parameters():
+        print(n, p.requires_grad)
+    trainable_params, all_param = get_nb_trainable_parameters(model)
+    print(
+        f"trainable params: {trainable_params:,d} || all params: {all_param:,d} || trainable%: {100 * trainable_params / all_param}"
+    )
+
+    ########
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        script_args.model_name_or_path,
+        model_max_length=script_args.model_max_length,
+        padding_side="right",
+        use_fast=True,
+        trust_remote_code=True,
+    )
+    tokenizer.pad_token_id = tokenizer.eos_token_id
+
+    raw_train_datasets = load_dataset(script_args.data_path, split=script_args.dataset_split)
+    train_dataset = raw_train_datasets.map(
+        train_tokenize_function,
+        batched=True,
+        batch_size=3000,
+        num_proc=16,  # 32
+        remove_columns=raw_train_datasets.column_names,
+        load_from_cache_file=True,
+        desc="Running tokenizer on train dataset",
+        fn_kwargs={
+            "tokenizer": tokenizer,
+            "query": script_args.dataset_field[0],
+            "response": script_args.dataset_field[1],
+        },
+    )
+
+    data_collator = DataCollatorForSupervisedDataset(tokenizer=tokenizer)
+    data_module = {
+        "train_dataset": train_dataset,
+        "data_collator": data_collator,
+    }
+    trainer = Trainer(model=model, tokenizer=tokenizer, args=script_args, **data_module)
+    model.config.use_cache = False
+    trainer.train()
+    trainer.save_state()
+    model.save_pretrained(os.path.join(script_args.output_dir, "ft"))
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    train()

--- a/examples/corda_finetuning/datautils.py
+++ b/examples/corda_finetuning/datautils.py
@@ -1,0 +1,277 @@
+import io
+import json
+import os
+import random
+
+import numpy as np
+import torch
+from datasets import load_dataset
+
+
+"""
+doc https://huggingface.co/docs/datasets/loading
+doc https://huggingface.co/docs/datasets/process
+doc https://huggingface.co/blog/llama2#how-to-prompt-llama-2
+"""
+
+
+def set_seed(seed):
+    np.random.seed(seed)
+    torch.random.manual_seed(seed)
+
+
+def sample_train_loaders(name, tokenizer, nsamples=128, seed=0, seqlen=2048):
+    set_seed(seed)
+    if "wikitext2" in name:
+        traindata = load_dataset(
+            "wikitext",
+            "wikitext-2-raw-v1",
+            split="train",
+        )
+        traindata = "\n\n".join(traindata["text"])
+    elif "c4" in name:
+        traindata = load_dataset(
+            "allenai/c4",
+            "allenai--c4",
+            data_files={"train": "en/c4-train.00000-of-01024.json.gz"},
+            split="train",
+        )
+        traindata = "\n\n".join(traindata["text"])
+    else:
+        raise NotImplementedError
+
+    trainloader = []
+    for _ in range(nsamples):
+        i = random.randint(0, len(traindata) - seqlen * 2 - 1)
+        j = i + seqlen * 2
+        # breakpoint()
+        trainenc = tokenizer(traindata[i:j], return_tensors="pt")
+        inp = trainenc.input_ids[:, :seqlen]
+        trainloader.append(inp)
+    return trainloader
+
+
+def get_redpajama_train(tokenizer, percent=10, seed=3, batch_size=128, max_length=2048):
+    def tokenization(example):
+        return tokenizer(example["text"], truncation=True, max_length=max_length)
+
+    if percent != 100:
+        split = f"train[:{int(850000*percent/100)}]"
+    else:
+        split = "train"
+    dataset = load_dataset("togethercomputer/RedPajama-Data-1T-Sample", split=split)
+
+    processed_dataset = dataset.map(tokenization, batched=True, batch_size=batch_size, num_proc=os.cpu_count())
+    return processed_dataset
+
+
+def get_english_quote(dataset_name, tokenizer):
+    data = load_dataset(dataset_name)
+    data = data.map(lambda samples: tokenizer(samples["quote"]), batched=True)
+    return data["train"]
+
+
+def get_qat_dataset(name, tokenizer, data_percent):
+    if name == "red_pajama":
+        data = get_redpajama_train(tokenizer, data_percent)
+
+    elif name == "Abirate/english_quotes":
+        data = get_english_quote(name, tokenizer)
+    else:
+        raise NotImplementedError
+    data = data.shuffle()
+    return data
+
+
+'''
+llama_chat_format="""<s>[INST] <<SYS>>
+"Below is an instruction that describes a task. Write a response that appropriately completes the request."
+<</SYS>>
+
+{{ instruction }} [/INST] {{ response }} </s>
+"""
+'''
+
+llama_chat_format = """<s>[INST] <<SYS>>
+"Below is an instruction that describes a task. Write a response that appropriately completes the request."
+<</SYS>>
+
+{instruction} [/INST] {response} </s>
+"""
+
+
+def _make_r_io_base(f, mode: str):
+    if not isinstance(f, io.IOBase):
+        f = open(f, mode=mode)
+        # f = open(f)
+    return f
+
+
+def jload(f, mode="r"):
+    """Load a .json file into a dictionary."""
+    f = _make_r_io_base(f, mode)
+    jdict = json.load(f)
+    f.close()
+    return jdict
+
+
+def get_calib_data(name, tokenizer, model_id, nsamples, seqlen=2048, seed=3):
+    print(f" get_data_from: {name}, nsamples={nsamples}, seqlen={seqlen}, {seed}")
+    cache_file = f"cache/{name}_{model_id.replace('/','_')}_{nsamples}_{seqlen}_{seed}.pt"
+    random.seed(seed)
+    if not os.path.exists("cache"):
+        os.makedirs("cache")
+    if os.path.exists(cache_file):
+        print(f"found data file: {cache_file}")
+        traindataset = torch.load(cache_file)
+        print("loaded ...")
+        return traindataset
+    if name == "c4":
+        traindata = load_dataset(
+            "allenai/c4",
+            "allenai--c4",
+            data_files={"train": "en/c4-train.00000-of-01024.json.gz"},
+            split="train",
+        )
+        tot_text = "\n\n".join(traindata["text"])
+    elif name == "wikitext2":
+        traindata = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+        tot_text = "\n\n".join(traindata["text"])
+    elif name == "ptb":
+        traindata = load_dataset(
+            "ptb_text_only",
+            "penn_treebank",
+            split="train",
+        )
+        tot_text = "\n\n".join(traindata["sentence"])
+    elif name == "traivia_qa":
+        traindata = load_dataset("trivia_qa", "rc", split="train")
+        tot_text = "\n\n".join(traindata["question"])
+    elif name == "nqopen":
+        traindata = load_dataset("nq_open", split="train")
+        tot_text = "\n\n".join(traindata["question"])
+    elif name == "alpaca":
+        # this is for chat models
+        data_path = "data/alpaca_data.json"
+        list_data_dict = jload(data_path)
+        traindataset = []
+        selected_data_dict = random.sample(list_data_dict, nsamples)
+        # random_indices = np.random.choice(len(list_data_dict), nsamples, replace=False)
+        # selected_data_dict = [list_data_dict[i] for i in random_indices]
+        for example in selected_data_dict:
+            if example.get("input", "") == "":
+                s = llama_chat_format.format(instruction=example["instruction"], response=example["output"])
+                trainenc = tokenizer(s, return_tensors="pt")
+                inp = trainenc.input_ids[:, :seqlen]
+                attention_mask = torch.ones_like(inp)
+                traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+        print("example instruction:", s)
+        torch.save(traindataset, cache_file)
+        return traindataset
+    elif name == "MetaMATH":
+        data_path = "data/MetaMathQA-395K.json"
+        list_data_dict = jload(data_path)
+        traindataset = []
+        selected_data_dict = random.sample(list_data_dict, nsamples)
+        for example in selected_data_dict:
+            if example.get("input", "") == "":
+                s = llama_chat_format.format(instruction=example["query"], response=example["response"])
+                trainenc = tokenizer(s, return_tensors="pt")
+                inp = trainenc.input_ids[:, :seqlen]
+                attention_mask = torch.ones_like(inp)
+                traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+        print("example instruction:", s)
+        torch.save(traindataset, cache_file)
+        return traindataset
+    elif name == "codefeedback":
+        data_path = "data/CodeFeedback-Filtered-Instruction.jsonl"
+        with open(data_path) as json_file:
+            json_list = list(json_file)
+        print(len(json_list))
+        list_data_dict = []
+        for item in json_list:
+            dict_item = json.loads(item)
+            list_data_dict.append(dict_item)
+            assert isinstance(dict_item, dict)
+        # list_data_dict = jload(data_path)
+        traindataset = []
+        # selected_data_dict=random.sample(list_data_dict, nsamples)
+        random_indices = np.random.choice(len(list_data_dict), nsamples, replace=False)
+        selected_data_dict = [list_data_dict[i] for i in random_indices]
+        for example in selected_data_dict:
+            if example.get("input", "") == "":
+                s = llama_chat_format.format(instruction=example["query"], response=example["answer"])
+                trainenc = tokenizer(s, return_tensors="pt")
+                inp = trainenc.input_ids[:, :seqlen]
+                attention_mask = torch.ones_like(inp)
+                traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+        print("example instruction:", s)
+        torch.save(traindataset, cache_file)
+        return traindataset
+    elif name == "WizLMinstruct":
+        data_path = "data/WizardLM_evol_instruct_V2_143k.jsonl"
+        with open(data_path) as json_file:
+            json_list = list(json_file)
+        print(len(json_list))
+        list_data_dict = []
+        for item in json_list:
+            dict_item = json.loads(item)
+            list_data_dict.append(dict_item)
+            assert isinstance(dict_item, dict)
+        # list_data_dict = jload(data_path)
+        traindataset = []
+        selected_data_dict = random.sample(list_data_dict, nsamples)
+        for example in selected_data_dict:
+            if example.get("input", "") == "":
+                s = llama_chat_format.format(
+                    instruction=example["conversation"][0]["human"], response=example["conversation"][0]["assistant"]
+                )
+                trainenc = tokenizer(s, return_tensors="pt")
+                inp = trainenc.input_ids[:, :seqlen]
+                attention_mask = torch.ones_like(inp)
+                traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+        print("example instruction:", s)
+        torch.save(traindataset, cache_file)
+        return traindataset
+    else:
+        raise NotImplementedError
+    print(f"tot_text={len(tot_text)}")
+    traindataset = []
+    for _ in range(nsamples):
+        i = random.randint(0, len(tot_text) - seqlen - 1)
+        j = i + seqlen * 10
+        trainenc = tokenizer(tot_text[i:j], return_tensors="pt")
+        inp = trainenc.input_ids[:, :seqlen]
+        attention_mask = torch.ones_like(inp)
+        traindataset.append({"input_ids": inp, "attention_mask": attention_mask})
+    torch.save(traindataset, cache_file)
+    return traindataset
+
+
+def get_eval_loaders(name, tokenizer):
+    if "wikitext2" in name:
+        testdata = load_dataset(
+            "wikitext",
+            "wikitext-2-raw-v1",
+            split="test",
+        )
+        testenc = tokenizer("\n\n".join(testdata["text"]), return_tensors="pt")
+        return testenc
+    if "ptb" in name:
+        valdata = load_dataset(
+            "ptb_text_only",
+            "penn_treebank",
+            split="validation",
+        )
+        testenc = tokenizer("\n\n".join(valdata["sentence"]), return_tensors="pt")
+        return testenc
+    if "c4" in name:
+        testdata = load_dataset(
+            "allenai/c4",
+            "allenai--c4",
+            data_files={"validation": "en/c4-validation.00000-of-00008.json.gz"},
+            split="validation",
+        )
+        testenc = tokenizer("\n\n".join(testdata["text"]), return_tensors="pt")
+        return testenc
+    raise NotImplementedError

--- a/examples/corda_finetuning/preprocess.py
+++ b/examples/corda_finetuning/preprocess.py
@@ -1,0 +1,153 @@
+import argparse
+import logging
+import os
+
+import numpy as np
+import torch
+from datautils import get_calib_data
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from peft.mapping import get_peft_model
+from peft.tuners.lora.config import CordaConfig, LoraConfig
+
+
+@torch.no_grad()
+def run_model(model, calib_loader):
+    model.eval()
+    for batch in tqdm(calib_loader):
+        batch = {k: v.to(model.device) for k, v in batch.items()}
+        model(**batch)
+
+
+def main(args):
+    # Setting random seed of numpy and torch
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    torch.backends.cudnn.deterministic = True
+
+    # Load model
+    model_id = args.model_id
+    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id, device_map="auto", torch_dtype=torch.float16, trust_remote_code=True
+    )
+
+    # Collect data
+    calib_loader = get_calib_data(args.calib_dataset, tokenizer, model_id, args.calib_loader_size, seed=args.seed)
+
+    # Evaluate the original model
+    print("\n---- model before svd ---\n")
+    print(model)
+
+    # Perform decomposition
+    config = LoraConfig(
+        init_lora_weights="corda",
+        target_modules=["q_proj", "o_proj", "k_proj", "v_proj", "gate_proj", "up_proj", "down_proj"],
+        r=args.r,
+        lora_alpha=args.r,
+        corda_config=CordaConfig(
+            run_model=lambda: run_model(model, calib_loader),
+            sample_count=args.calib_loader_size,
+            corda_method="ipm" if args.first_eigen else "kpm",
+            cache_file="./checkpoints/cov/debug.pt",
+            run_svd_for_covariance=False,
+        ),
+    )
+    model = get_peft_model(model, config)
+
+    # Evaluate again to check if the model is consistent
+    # Using `model.model` here because `get_peft_model` wraps a layer to the model
+    print("\n---- model after svd ---\n")
+    print(model)
+
+    # Save as hugging face model
+    if args.save_model:
+        assert args.save_path is not None
+        save_path = args.save_path
+
+        # Save CorDA modules
+        model.peft_config["default"].init_lora_weights = True
+        model.save_pretrained(os.path.join(save_path, "corda_init"))
+
+        # Save residual model
+        model = model.unload()
+        model.save_pretrained(save_path)
+
+        # Save tokenizer
+        tokenizer.save_pretrained(save_path)
+        print(f"Done building CorDA huggingface model in {save_path}")
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="meta-llama/Llama-2-7b-hf",
+        help="Pretrained model ID",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.5,
+        help="hyper-parameter alpha for ASVD",
+    )
+    parser.add_argument(
+        "--calib_loader_size",
+        type=int,
+        default=256,
+        help="number of samples used for covariance matrices",
+    )
+    parser.add_argument(
+        "--calib_dataset",
+        type=str,
+        default="wikitext2",
+        choices=[
+            "wikitext2",
+            "c4",
+            "ptb",
+            "traivia_qa",
+            "nqopen",
+            "MetaMATH",
+            "codefeedback",
+            "WizLMinstruct",
+            "alpaca",
+        ],
+        help="calibration dataset",
+    )
+    parser.add_argument(
+        "--eval_mmlu",
+        action="store_true",
+        help="evaluate mmlu",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=233,
+        help="random seed",
+    )
+    parser.add_argument(
+        "--r",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "--first_eigen",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--save_model",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--save_path",
+        type=str,
+        default=None,
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Union
+from typing import Callable, Literal, Optional, Union
 
 from torch import nn
 
@@ -121,6 +121,100 @@ class EvaConfig:
 
 
 @dataclass
+class CordaConfig:
+    """
+    This is the sub-configuration class to store the configuration of a [`LoraModel`].
+
+    Args:
+        cache_file (`Optional[str]`):
+            File to store the SVD cache. The SVD cache is much smaller than the residual model (for example, residual
+            model of Llama-3-8b is 15GB, while SVD cache is 1.4GB), but with SVD cache and original model weights,
+            residual model weights can be built quickly. If you need to reuse residual model weights with limited
+            storage, you can store the SVD cache instead.
+        covariance_file (`Optional[str]`):
+            File to store the covariance matrix. If you wish to train multiple models with different ranks, but they
+            sample from the same dataset, you can store the covariance matrix and reuse it for different ranks. Note
+            that covariance file is usually large (comparable to model size), so you will need sufficient storage.
+        run_model (`Callable[[], None]`):
+            Callback to run the model when building covariance. This will be run once regardless of `sample_count`, so
+            you should configure the `run_model` callback to run the model exactly `sample_count` times. Typically you
+            should run model inference on your dataset in this callback.
+        hooked_model (`Optional[nn.Module]`):
+            Model to hook when building covariance. If none, original model will be hooked. This is only useful when
+            you want to hook a different model than the one you are training, typically you should leave this `None`.
+        sample_count (`int`):
+            Divisor for each hook call. You should make sure `run_model` calls the model exactly `sample_count` times
+            for consistent behaviour.
+        corda_method (`Literal["ipm", "kpm"]`):
+            Method to build adapter. The KPM not only achieves better performance than LoRA on fine-tuning tasks, but
+            also mitigates the catastrophic forgetting of pre-trained world knowledge. When preserving pre-trained
+            knowledge is not a concern, the IPM is favored because it can further accelerate convergence and enhance
+            the fine-tuning performance.
+    """
+
+    cache_file: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "File to store the SVD cache. The SVD cache is much smaller than the residual model (for example, "
+                "residual model of Llama-3-8b is 15GB, while SVD cache is 1.4GB), but with SVD cache and original model "
+                "weights, residual model weights can be built quickly. If you need to reuse residual model weights with "
+                "limited storage, you can store the SVD cache instead."
+            )
+        },
+    )
+    covariance_file: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "File to store the covariance matrix. If you wish to train multiple models with different ranks, but "
+                "they sample from the same dataset, you can store the covariance matrix and reuse it for different ranks. "
+                "Note that covariance file is usually large (comparable to model size), so you will need sufficient storage."
+            )
+        },
+    )
+    run_model: Optional[Callable[[], None]] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Callback to run the model when building covariance. This will be run once regardless of `sample_count`, "
+                "so you should configure the `run_model` callback to run the model exactly `sample_count` times. Typically "
+                "you should run model inference on your dataset in this callback."
+            )
+        },
+    )
+    hooked_model: Optional[nn.Module] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Model to hook when building covariance. If none, original model will be hooked. This is only useful when "
+                "you want to hook a different model than the one you are training, typically you should leave this `None`."
+            )
+        },
+    )
+    sample_count: int = field(
+        default=256,
+        metadata={
+            "help": (
+                "Divisor for each hook call. You should make sure `run_model` calls the model exactly `sample_count` times "
+                "for consistent behaviour."
+            )
+        },
+    )
+    corda_method: Literal["ipm", "kpm"] = field(
+        default="ipm",
+        metadata={
+            "help": (
+                "Method to build adapter. The KPM not only achieves better performance than LoRA on fine-tuning tasks, but "
+                "also mitigates the catastrophic forgetting of pre-trained world knowledge. When preserving pre-trained "
+                "knowledge is not a concern, the IPM is favored because it can further accelerate convergence and enhance "
+                "the fine-tuning performance."
+            )
+        },
+    )
+
+
+@dataclass
 class LoraConfig(PeftConfig):
     """
     This is the configuration class to store the configuration of a [`LoraModel`].
@@ -199,6 +293,9 @@ class LoraConfig(PeftConfig):
         eva_config (`Optional[EvaConfig]`):
             The configuration of EVA. At a minimum the dataset argument needs to be set (use the same dataset as for
             finetuning).
+        corda_config (`Optional[CordaConfig]`):
+            The configuration of CorDA. If this is not None, then CorDA will be used to build the adapter layers. Also
+            pass `init_lora_weights='corda'`.
         use_dora (`bool`):
             Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the weights
             into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is
@@ -356,6 +453,15 @@ class LoraConfig(PeftConfig):
             )
         },
     )
+    corda_config: Union[CordaConfig, dict] = field(
+        default_factory=dict,
+        metadata={
+            "help": (
+                "The configuration of CorDA. If this is passed, then CorDA will be used to build the adapter layers. "
+                "Also set `init_lora_weights='corda'` in this case."
+            )
+        },
+    )
     use_dora: bool = field(
         default=False,
         metadata={
@@ -464,6 +570,10 @@ class LoraConfig(PeftConfig):
                 "base weights; if you intend to do this, please ensure not to use rslora or rank_pattern/alpha_pattern."
             )
             warnings.warn(msg)
+
+        # convert corda_config to dict
+        if self.corda_config and not isinstance(self.corda_config, dict):
+            self.corda_config = vars(self.corda_config)
 
         self._custom_modules: Optional[dict[type[nn.Mmodule], type[nn.Module]]] = None
 

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 import math
 import warnings
 from typing import Any, Optional, Union
@@ -129,6 +130,9 @@ class LoraLayer(BaseTunerLayer):
         if isinstance(init_lora_weights, str) and init_lora_weights.startswith("pissa"):
             with gather_params_ctx(self.get_base_layer().weight):
                 self.pissa_init(adapter_name, init_lora_weights)
+        elif isinstance(init_lora_weights, str) and init_lora_weights.startswith("corda"):
+            with gather_params_ctx(self.get_base_layer().weight):
+                self.corda_init(adapter_name, init_lora_weights)
         elif isinstance(init_lora_weights, str) and init_lora_weights.lower() == "olora":
             with gather_params_ctx(self.get_base_layer().weight):
                 self.olora_init(adapter_name)
@@ -248,6 +252,66 @@ class LoraLayer(BaseTunerLayer):
         self.lora_B[adapter_name].weight.data = lora_B
         weight = weight.data - self.scaling[adapter_name] * lora_B @ lora_A
         weight = transpose(weight.to(dtype), self.fan_in_fan_out)
+        self.get_base_layer().weight.data = weight
+
+    def corda_init(self, adapter_name, init_lora_weights):
+        linear = self.get_base_layer()
+        weight = linear.weight
+        dtype = weight.dtype
+        if dtype not in [torch.float32, torch.float16, torch.bfloat16]:
+            raise TypeError(
+                "Please initialize CorDA under float32, float16, or bfloat16. "
+                "Subsequently, re-quantize the residual model to help minimize quantization errors."
+            )
+        weight = weight.to(torch.float32)
+        out_dim = weight.data.size(0)
+        in_dim = weight.data.size(1)
+
+        # Calculate WC from covariance matrix
+        assert hasattr(linear, "eigens")
+        eigens = linear.eigens
+        U = eigens.U_WC
+        S = eigens.S_WC
+        V = eigens.V_WC
+        r = self.r[adapter_name]
+
+        # nan or inf check
+        # if (S!=S).any():
+        if torch.isnan(S).any() or torch.isinf(S).any():
+            # print("nan in S")
+            raise Exception("nan or inf in S")
+        # if (U!=U).any():
+        if torch.isnan(U).any() or torch.isinf(U).any():
+            # print("nan in U")
+            raise Exception("nan or inf in U")
+        # if (V!=V).any():
+        if torch.isnan(V).any() or torch.isinf(V).any():
+            # print("nan in V")
+            raise Exception("nan or inf in V")
+
+        # Sanity check
+        logging.info(f"U.device = {U.device}, S.device = {S.device}, V.device = {V.device}")
+        logging.info(f"weight.data.device = {weight.data.device}")
+        svd_error = torch.dist(U @ torch.diag(S) @ V.t(), weight.data)
+        scale_u = torch.linalg.norm(U) / math.sqrt(r)
+        scale_v = torch.linalg.norm(V) / math.sqrt(r)
+        logging.info(f"scale_u: {scale_u:.2f}, scale_v: {scale_v:.2f}, svd_error: {svd_error:.2f}")
+        assert U.size(0) == out_dim
+        assert U.size(1) == r
+        assert S.size(0) == r
+        assert V.size(0) == in_dim
+        assert V.size(1) == r
+
+        # Apply alpha
+        S /= self.scaling[adapter_name]
+
+        # Init lora_A and lora_B weights
+        lora_A = V.t().mul(S.sqrt().view(-1, 1)).contiguous()
+        lora_B = U.mul(S.sqrt()).contiguous()
+        self.lora_A[adapter_name].weight.data = lora_A
+        self.lora_B[adapter_name].weight.data = lora_B
+        weight = weight.data - self.scaling[adapter_name] * lora_B @ lora_A
+        weight = weight.to(dtype)
         self.get_base_layer().weight.data = weight
 
     def loftq_init(self, adapter_name):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -42,6 +42,7 @@ from peft.utils import (
     get_peft_model_state_dict,
     get_quantization_config,
 )
+from peft.utils.corda_utils import preprocess_corda
 from peft.utils.merge_utils import dare_linear, dare_ties, magnitude_prune, task_arithmetic, ties
 from peft.utils.other import get_pattern_key
 
@@ -139,6 +140,11 @@ class LoraModel(BaseTuner):
 
     def __init__(self, model, config, adapter_name, low_cpu_mem_usage: bool = False) -> None:
         super().__init__(model, config, adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)
+
+    def _pre_injection_hook(self, model: nn.Module, config: LoraConfig, adapter_name: str) -> None:
+        if isinstance(config.init_lora_weights, str) and config.init_lora_weights.startswith("corda"):
+            if not hasattr(model, "corda_method"):
+                preprocess_corda(model, config)
 
     def _check_new_adapter_config(self, config: LoraConfig) -> None:
         """

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -154,6 +154,9 @@ class LoraParallelLinear(nn.Module, LoraLayer):
         if isinstance(init_lora_weights, str) and init_lora_weights.startswith("pissa"):
             with gather_params_ctx(self.get_base_layer().weight):
                 self.pissa_init(adapter_name, init_lora_weights)
+        elif isinstance(init_lora_weights, str) and init_lora_weights.startswith("corda"):
+            with gather_params_ctx(self.get_base_layer().weight):
+                self.corda_init(adapter_name, init_lora_weights)
         elif isinstance(init_lora_weights, str) and init_lora_weights.lower() == "olora":
             with gather_params_ctx(self.get_base_layer().weight):
                 self.olora_init(adapter_name)

--- a/src/peft/utils/corda_utils.py
+++ b/src/peft/utils/corda_utils.py
@@ -1,0 +1,314 @@
+import logging
+import os
+from typing import Any, Callable, Iterable, Optional
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+
+from peft.tuners.lora.config import LoraConfig
+from peft.tuners.tuners_utils import check_target_module_exists
+from peft.utils.other import get_pattern_key
+
+
+class CordaEigens:
+    S_WC: torch.Tensor
+    U_WC: torch.Tensor
+    V_WC: torch.Tensor
+
+    def __init__(
+        self,
+        S_WC: torch.Tensor,
+        U_WC: torch.Tensor,
+        V_WC: torch.Tensor,
+    ):
+        self.S_WC = S_WC
+        self.U_WC = U_WC
+        self.V_WC = V_WC
+
+
+@torch.no_grad()
+def target_modules(model: nn.Module, config: LoraConfig) -> Iterable[nn.Module]:
+    """
+    Iterate over CorDA target name and modules of a model. A module is a target if its name is in
+    `config.target_modules` and is `nn.Linear`.
+    """
+    for name, module in model.named_modules():
+        if check_target_module_exists(config, name) and isinstance(module, nn.Linear):
+            yield name, module
+
+
+@torch.no_grad()
+def get_model_device(model: nn.Module) -> str:
+    if hasattr(model, "module"):  # Handle DeepSpeed/DataParallel
+        model = model.module
+    return "cuda" if next(iter(model.parameters())).is_cuda else "cpu"
+
+
+@torch.no_grad()
+def preprocess_corda(
+    model: nn.Module,
+    config: LoraConfig,
+):
+    """
+    Build necessary CorDA fields for a model.
+
+    The fields are:
+        corda_method (`Literal["ipm", "kpm"]`):
+            CorDA method to apply. "ipm" for Instruction-Previewed Mode, "kpm" for Knowledge-Preserved Mode.
+        rank (`int`):
+            Rank of CorDA to apply.
+        eigens.S_WC (`torch.Tensor`):
+            Singular values of the weight matrix.
+        eigens.U_WC (`torch.Tensor`):
+            Left singular vectors of the weight matrix.
+        eigens.V_WC (`torch.Tensor`):
+            Right singular vectors of the weight matrix, multiplied by inverse of covariance matrix.
+    """
+    logging.info(f"model device: {get_model_device(model)}")
+    cache_file = config.corda_config.get("cache_file")
+    covariance_file = config.corda_config.get("covariance_file")
+    sample_count = config.corda_config.get("sample_count")
+    corda_method = config.corda_config.get("corda_method")
+    run_model = config.corda_config.get("run_model")
+    hooked_model = config.corda_config.get("hooked_model")
+
+    # If cache exists, skip building
+    if cache_file is not None and os.path.exists(cache_file) and os.path.getsize(cache_file) > 0:
+        logging.info(f"CorDA cache file found: {cache_file}")
+        cache = torch.load(cache_file, map_location=get_model_device(model))
+        for name, module in target_modules(model, config):
+            module.corda_method = cache[f"{name}.corda_method"]
+            module.rank = cache[f"{name}.rank"]
+            module.eigens = CordaEigens(
+                S_WC=cache[f"{name}.eigens.S_WC"],
+                U_WC=cache[f"{name}.eigens.U_WC"],
+                V_WC=cache[f"{name}.eigens.V_WC"],
+            )
+        logging.info(f"CorDA cache loaded from {cache_file}")
+    else:
+        # Cache file not found, build CorDA fields
+        logging.info("CorDA cache file not found, building...")
+
+        # Specify CorDA method for each layer
+        assert corda_method is not None, "corda_method is required when cache_file is not provided"
+        for name, module in target_modules(model, config):
+            module.corda_method = corda_method
+
+        # Specify CorDA rank for each layer
+        for name, module in target_modules(model, config):
+            r_key = get_pattern_key(config.rank_pattern.keys(), name)
+            module.rank = config.rank_pattern.get(r_key, config.r)
+
+        # Calculate covariance matrix
+        calib_cov_distribution(model, config, run_model, hooked_model, sample_count, covariance_file)
+
+        # Calculate eigens
+        collect_eigens(model, config)
+
+        # Crop CorDA eigens so that there's less to save
+        crop_corda_eigens(model, config)
+
+        # Save cache to disk
+        if cache_file is not None:
+            cache: dict[str, Any] = {}
+            for name, module in target_modules(model, config):
+                cache[f"{name}.corda_method"] = module.corda_method
+                cache[f"{name}.rank"] = module.rank
+                cache[f"{name}.eigens.S_WC"] = module.eigens.S_WC
+                cache[f"{name}.eigens.U_WC"] = module.eigens.U_WC
+                cache[f"{name}.eigens.V_WC"] = module.eigens.V_WC
+
+            os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+            torch.save(cache, cache_file)
+            logging.info(f"CorDA cache saved at {cache_file}")
+
+    # Clear run model callback as it's not serializable
+    config.corda_config["run_model"] = None
+    config.corda_config["hooked_model"] = None
+
+
+@torch.no_grad()
+def calib_cov_distribution(
+    model: nn.Module,
+    config: LoraConfig,
+    run_model: Optional[Callable[[], None]],
+    hooked_model: Optional[nn.Module],
+    sample_count: int,
+    covariance_file: Optional[str],
+):
+    if covariance_file is not None and os.path.exists(covariance_file) and os.path.getsize(covariance_file) > 0:
+        logging.info(f"covariance file found: {covariance_file}")
+        all_covariance_matrix = torch.load(covariance_file, map_location=get_model_device(model))
+        for name, module in target_modules(model, config):
+            module.covariance_matrix = all_covariance_matrix[name]
+        return
+
+    assert run_model is not None, "run_model must be specified when covariance file and cache file aren't built"
+    if hooked_model is None:
+        hooked_model = model
+    hooked_model.eval()
+    logging.info(f"sample count: {sample_count}")
+
+    def hook(module, input, output):
+        input = input[0].detach().squeeze(0).data  ## (context_length = 2048, dim)
+        if config.corda_config.get("use_float32_for_covariance", True):
+            input = input.float()
+        input = input / torch.max(input).abs()
+
+        # covariance = input.t() @ input ## (dim, dim)
+        if torch.isnan(input).any():
+            logging.info("nan detected")
+            raise Exception("nan in input, break")
+        if torch.isinf(input).any():
+            logging.info("inf detected")
+            raise Exception("inf in input, break")
+
+        covariance = input.t().matmul(input)
+        if torch.isnan(covariance).any():
+            logging.info("nan detected")
+            raise Exception("nan in covariance, break")
+        if torch.isinf(covariance).any():
+            logging.info("inf detected")
+            raise Exception("inf in covariance, break")
+
+        # calculate mean and std
+        mean = input.mean(0)
+        std = input.std(0)
+
+        # add to module
+        module.covariance_matrix += covariance / sample_count
+        module.mean += mean / sample_count
+        module.std += std / sample_count
+
+        # module.covariance_matrix = (module.covariance_matrix + covariance) / 2
+        del covariance, input
+
+    logging.info("registering forward hook")
+    for name, module in target_modules(hooked_model, config):
+        module.covariance_matrix = 0
+        module.mean = 0
+        module.std = 0
+        module.register_forward_hook(hook)
+
+    logging.info("running model")
+    run_model()
+    logging.info("covariance matrices stored in hooked model")
+
+    if hooked_model is not model:
+        targets = {}
+        for name, module in target_modules(model, config):
+            targets[name] = module
+        for name, module in target_modules(hooked_model, config):
+            # There can be modules used only in inference, but not training
+            # Exclude modules not in target model to prevent KeyError in this case
+            if name in targets:
+                targets[name].covariance_matrix = module.covariance_matrix
+                targets[name].mean = module.mean
+                targets[name].std = module.std
+        logging.info("covariance matrices copied to model")
+
+    # Save covariance to disk
+    if covariance_file is not None:
+        all_covariance_matrix = {}
+        for name, module in target_modules(model, config):
+            all_covariance_matrix[name] = module.covariance_matrix
+        os.makedirs(os.path.dirname(covariance_file), exist_ok=True)
+        torch.save(all_covariance_matrix, covariance_file)
+        logging.info(f"covariance saved at {covariance_file}")
+
+
+@torch.no_grad()
+def collect_eigens(
+    model: nn.Module,
+    config: LoraConfig,
+):
+    """Call collect_eigens_for_layer and store result in key `eigens` of each layer."""
+    linear_modules = []
+    for name, module in target_modules(model, config):
+        linear_modules.append((name, module))
+    for name, module in tqdm(linear_modules, desc="Collecting eigens"):
+        module.eigens = collect_eigens_for_layer(module, config)
+
+
+@torch.no_grad()
+def collect_eigens_for_layer(
+    linear: nn.Linear,
+    config: LoraConfig,
+) -> CordaEigens:
+    w = linear.weight.data.float()
+    out_dim = w.size(0)
+    in_dim = w.size(1)
+    min_dim = min(in_dim, out_dim)
+
+    assert hasattr(linear, "covariance_matrix")
+    covariance_matrix = linear.covariance_matrix.float()
+
+    damp = 0.01
+    while True:
+        compensate = torch.diag(
+            torch.ones(covariance_matrix.size(0)).to(covariance_matrix.device)
+            * torch.mean(torch.diag(covariance_matrix))
+            * damp
+        )
+        fix_covariance_matrix = covariance_matrix + compensate
+        cov_inv = torch.linalg.inv(fix_covariance_matrix)
+        inv_error = torch.dist(
+            fix_covariance_matrix @ cov_inv, torch.eye(covariance_matrix.size(0)).to(get_model_device(linear))
+        ).item()
+        logging.info(f"size: {covariance_matrix.size()}, dtype: {covariance_matrix.dtype}")
+        logging.info(f"damp: {damp}, inv_error: {inv_error}")
+        if inv_error < 0.05:
+            break
+        else:
+            damp = damp * 2
+    w = w @ fix_covariance_matrix  ## w: out_dim, in_dim; covariance_matrix: in_dim, in_dim
+
+    U, S, Vh = torch.linalg.svd(w, full_matrices=False)
+    V = (Vh @ cov_inv).transpose(0, 1)
+
+    norm_of_VandCovinv = torch.sqrt((V**2).sum(dim=0))
+    logging.info(f"norm_of_VandCovinv: {norm_of_VandCovinv[:16]} ... {norm_of_VandCovinv[-16:]}")
+    logging.info(f"S: {S[:16]} ... {S[-16:]}")
+
+    # Sanity check, temporarily U and V are large, they will be crop after rank search
+    assert U.size(0) == out_dim
+    assert U.size(1) == min_dim
+    assert S.size(0) == min_dim
+    assert V.size(0) == in_dim
+    assert V.size(1) == min_dim
+
+    # Offload U and V to CPU, they consume too much memory
+    U = U.cpu()
+    V = V.cpu()
+    return CordaEigens(
+        S_WC=S,
+        U_WC=U,
+        V_WC=V,
+    )
+
+
+@torch.no_grad()
+def crop_corda_eigens(model: nn.Module, config: LoraConfig):
+    for name, module in target_modules(model, config):
+        # We don't expect saving sliced tensor writes the whole tensor to disk,
+        # so it's necessary to copy the tensors.
+        # Reference: https://github.com/pytorch/pytorch/issues/40157
+        if module.corda_method == "ipm":
+            module.eigens.S_WC = module.eigens.S_WC[: module.rank].clone()
+            module.eigens.U_WC = module.eigens.U_WC[:, : module.rank].clone().to(get_model_device(model))
+            module.eigens.V_WC = module.eigens.V_WC[:, : module.rank].clone().to(get_model_device(model))
+        elif module.corda_method == "kpm":
+            module.eigens.S_WC = module.eigens.S_WC[-module.rank :].clone()
+            module.eigens.U_WC = module.eigens.U_WC[:, -module.rank :].clone().to(get_model_device(model))
+            module.eigens.V_WC = module.eigens.V_WC[:, -module.rank :].clone().to(get_model_device(model))
+        else:
+            raise ValueError("Invalid corda_method")
+
+        # Sanity check
+        assert module.eigens.S_WC.size(0) == module.rank
+        assert module.eigens.U_WC.size(0) == module.weight.size(0)
+        assert module.eigens.U_WC.size(1) == module.rank
+        assert module.eigens.V_WC.size(0) == module.weight.size(1)
+        assert module.eigens.V_WC.size(1) == module.rank
+    logging.info("CorDA eigens cropped")

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -16,6 +16,7 @@
 import itertools
 import platform
 import re
+import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
@@ -54,6 +55,7 @@ from peft import (
     inject_adapter_in_model,
     set_peft_model_state_dict,
 )
+from peft.tuners.lora.config import CordaConfig
 from peft.tuners.lora.layer import LoraLayer
 from peft.utils import infer_device
 from peft.utils.hotswap import hotswap_adapter
@@ -327,6 +329,85 @@ class TestLoraInitialization:
         config = LoraConfig(init_lora_weights="pissa_niter_16", target_modules=["linear"])
         peft_model = get_peft_model(deepcopy(model), config)
         assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
+
+    def test_lora_corda_linear_init_default(self, data):
+        model = self.get_model()
+        output = model(data)[0]
+
+        with tempfile.NamedTemporaryFile() as corda_cache_fp:
+            with tempfile.NamedTemporaryFile() as covariance_cache_fp:
+                config = LoraConfig(
+                    init_lora_weights="corda",
+                    target_modules=["linear"],
+                    corda_config=CordaConfig(
+                        cache_file=corda_cache_fp.name,
+                        covariance_file=covariance_cache_fp.name,
+                        run_model=lambda: model(data),
+                        hooked_model=model,
+                        sample_count=1,
+                    ),
+                )
+                peft_model = get_peft_model(deepcopy(model), config)
+                assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
+
+                # If load SVD result from cache, the output should be the same
+                config = LoraConfig(
+                    init_lora_weights="corda",
+                    target_modules=["linear"],
+                    corda_config=CordaConfig(cache_file=corda_cache_fp.name),
+                )
+                peft_model = get_peft_model(deepcopy(model), config)
+                assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
+
+                # If load covariance from cache, the output should be the same
+                config = LoraConfig(
+                    init_lora_weights="corda",
+                    target_modules=["linear"],
+                    corda_config=CordaConfig(covariance_file=covariance_cache_fp.name),
+                )
+                peft_model = get_peft_model(deepcopy(model), config)
+                assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
+
+    def test_lora_corda_linear_init_default_with_rank_pattern(self, data):
+        model = self.get_model()
+        output = model(data)[0]
+
+        with tempfile.NamedTemporaryFile() as corda_cache_fp:
+            with tempfile.NamedTemporaryFile() as covariance_cache_fp:
+                config = LoraConfig(
+                    rank_pattern={"linear": 8, "embed": 16, "conv2d": 32},
+                    init_lora_weights="corda",
+                    target_modules=["linear"],
+                    corda_config=CordaConfig(
+                        cache_file=corda_cache_fp.name,
+                        covariance_file=covariance_cache_fp.name,
+                        run_model=lambda: model(data),
+                        hooked_model=model,
+                        sample_count=1,
+                    ),
+                )
+                peft_model = get_peft_model(deepcopy(model), config)
+                assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
+
+                # If load SVD result from cache, the output should be the same
+                config = LoraConfig(
+                    rank_pattern={"linear": 8, "embed": 16, "conv2d": 32},
+                    init_lora_weights="corda",
+                    target_modules=["linear"],
+                    corda_config=CordaConfig(cache_file=corda_cache_fp.name),
+                )
+                peft_model = get_peft_model(deepcopy(model), config)
+                assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
+
+                # If load covariance from cache, the output should be the same
+                config = LoraConfig(
+                    rank_pattern={"linear": 8, "embed": 16, "conv2d": 32},
+                    init_lora_weights="corda",
+                    target_modules=["linear"],
+                    corda_config=CordaConfig(covariance_file=covariance_cache_fp.name),
+                )
+                peft_model = get_peft_model(deepcopy(model), config)
+                assert torch.allclose(output, peft_model(data)[0], atol=1e-06)
 
     def test_lora_olora_linear_init_default(self, data):
         model = self.get_model()


### PR DESCRIPTION
Existing PEFT methods are mostly agnoistic of the context of a task of concern, e.g., a downstraem task to learn or some pre-trained world knowledge to maintain.
In our paper (https://openreview.net/pdf?id=Gi00NVru6n) accepted by NeurIPS 2024, we propose a PEFT method named Corda, context-oriented decomposition adaptation, which builds task-aware LoRA adapters from weight decomposition oriented by the context of the task concerned. 

Concretely, CorDA randomly collect a few (usually 256) data samples from a target task, e.g. questions from a QA dataset or instructions to write a code or solve a math problem, and feed these samples into a pre-trained LLM. We can obtain the covariance matrix of the input activation of each linear layer, i.e., $C=XX^T\in\mathcal{R}^{d_{in}\times d_{in}}$, where $X$ is the input of this linear layer. 
We then perform singular value decomposition (SVD) for the weight $W\in \mathcal{R}^{d_{out}\times d_{in}}$ multiplied by the covariance matrix, i.e., $\verb|SVD|(WC) = U\Sigma V^T$, where $U$ and $V$ are singular vectors and $\Sigma$ is the diagonal matrix with the singular values arranged in descending order. In this way, the context expressed by these representative covariance matrices is able to orientate the decomposition, such that the principal components are most associated with the task of concern. To ensure the same inference result with the pre-trained model at the start of adaptation, we multiply the inverse of these covariance matrices with the decomposed components, $\hat{W}=U\Sigma V^T C^{-1}$, where $\hat{W}$ is the weight after decomposition and reconstruction. 

Thanks to the task-awareness, CorDA enables two optional modes, **knowledge-preserving adaptation mode (KPM)** and **instruction-previewed adaptation mode (IPM**). In KPM, we use questions from question-answering dataset whose knowledge needs to be preserved, such as TriviaQA and NQopen, to obtain the covariance matrices. After our context-oriented decomposition, we use the components with the smallest $r$ singular values, $U_{[:,-r:]}$, $\Sigma_{[-r:]}$, and $(V^TC^{-1})\_{\left[-r:,:\right]}$ to initialize the learnable LoRA adapters $A=\sqrt{\Sigma}\_{[-r:]}(V^TC^{-1})\_{[-r:,:]}$ and $B=U\_{[:,-r:]}\sqrt{\Sigma}\_{[-r:]}$. The other components that compact the question-answering ability are frozen during adaptation. 
KPM enables to learn new tasks effectively while keeping the world knowledge associated with $C$ as sound
as possible.
Alternatively, when one only aims to achieve performance as high as possible on the finetuning task without concern for world knowledge maintenance, our IPM will be favored. 
In this mode, CorDA uses the instruction and response from the fine-tuning task (e.g., Math or Code) to produce the covariance matrices. The principal components with large singular values capturing the characteristics of the finetuning task in advance can better accommodate the new ability. So we initialize adapters as $A= \sqrt{\Sigma}_{[:r]} (V^T C^{-1})_{[:r,:]}$ and $B =U_{[:,:r]} \sqrt{\Sigma}_{[:r]}$, and freeze the remaining components. The implementations of KPM and IPM are compared as follows:

| Mode | Collect covariance from | LoRA $A$ | LoRA $B$ |
|---|---|---|---
|KPM | questions from a knowledge benchmark to maintain | $A=\sqrt{\Sigma}\_{[-r:]}(V^T C^{-1})\_{[-r:,:]}$ | $B=U_{[:,-r:]}\sqrt{\Sigma}_{[-r:]}$ |
IPM | instructions and responses from a downstream task to learn | $A= \sqrt{\Sigma}\_{[:r]} (V^T C^{-1})\_{[:r,:]}$ | $B =U_{[:,:r]} \sqrt{\Sigma}_{[:r]}$ |

![fig1](https://github.com/user-attachments/assets/c6f2e20a-b188-4cca-b992-222b9bee93ad)

Similar to PiSSA, our method is also an initialization method for LoRA adapter with the same LoRA structure, and our IPM also uses the principal components to initialize $A$ and $B$. But PiSSA adopts the naive SVD and does not consider task awareness. Our method builds task-aware adapters, enabling two optional modes to satisfy customized needs. Moreover, our IPM also surpasses PiSSA on downstream performance in some experiments. Some results are shown below. 

1. The superiority of our decomposition method.

![fig2](https://github.com/user-attachments/assets/4de399f1-4616-47c4-a946-81f097597ff7)


Plain SVD is the normal SVD on pre-trained weights, as adopted by PiSSSA. This experiment discards the smallest $r$ components after different decomposition methods and tests the perplexity on Wiki and PTB. It indicates that our decomposition better compacts task abilities into the principal components, and thus can better maintain the corresponding knowledge by freezing them in KPM, or better learn new abilities by adapting them in IPM. 


2. Adaptation performance with knowledge-preserving mode

| Method | Model | NQ open | GSM8k | Math | Avg. |
|---|---|---|---|---|---|
|Pre-trained|Llama-2-7b| 14.99 | -| - | - |
|LoRA|Llama-2-7b|1.27| 42.68 | 5.88 | 16.61 |
|CorDA (KPM) |Llama-2-7b| 8.20 | 46.32	| 7.00 | 20.51 |
|Pre-trained|Llama-2-13b|23.63|-|-|-|
|LoRA|Llama-2-13b| 16.26 | 57.24 | 8.92 | 27.47 |
|CorDA (KPM) |Llama-2-13b| 19.86 | 59.29 | 9.62 | 29.59 |
|Pre-trained|Llama-3-8b|13.41|-|-|-|
|LoRA|Llama-3-8b| 8.75 | 72.33 | 24.04| 35.04 |
|CorDA (KPM) |Llama-3-8b| 9.61 | 74.68 | 25.34| 36.54 |
|Pre-trained|Gemma-2-9b|12.85|-|-|-|
|LoRA|Gemma-2-9b| 9.28 | 83.47 | 42.30| 45.02 |
|CorDA (KPM) |Gemma-2-9b|10.17 | 84.08 | 42.64| 45.63 |


3. Adaptation performance with instruction-previewed mode

| Method | Model | GSM8k | Math |
| --- | --- | --- | ---|
|LoRA| Llama-2-7b | 42.68 | 5.88 |
|PiSSA | Llama-2-7b | 51.63 | 7.32 |
| CorDA (IPM) | Llama-2-7b | 53.45 | 8.64 |
|LoRA| Llama-2-13b | 57.24 | 8.92 |
|PiSSA | Llama-2-13b |60.88	| 11.08|
| CorDA (IPM) | Llama-2-13b | 62.47	|11.54 |
|LoRA| Gemma-2-9b | 83.47 |	42.30 |
|PiSSA | Gemma-2-9b | 84.23	| 43.52|
| CorDA (IPM) | Gemma-2-9b | 84.45 | 43.88|

![fig3](https://github.com/user-attachments/assets/aa929684-0a55-4a3a-8e48-257b067dabf1)
